### PR TITLE
next vs lib path aliases

### DIFF
--- a/apps/next-site/src/app/Unused-in-next-site.tsx
+++ b/apps/next-site/src/app/Unused-in-next-site.tsx
@@ -1,0 +1,3 @@
+export function Unused_in_next_site() {
+  return <h1>Unused in next site</h1>
+}

--- a/apps/next-site/tsconfig.json
+++ b/apps/next-site/tsconfig.json
@@ -6,8 +6,15 @@
         "name": "next"
       }
     ],
+    "baseUrl": "./src/",
     "paths": {
-      "@hello-knip/lib-1": ["../libs/lib-1"] ,
+      "@hello-knip/lib-1/*": [
+        // Relative to src:
+        // 1. src
+        // 2. next-site
+        // 3. apps
+        "../../../libs/lib-1/*"
+      ],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
`tsconfig.json` with

```
    "baseUrl": "src",
    "paths": {
      "@hello-knip/lib-1/*": ["../../../libs/lib-1/*"]
    }
```

Makes knip not consider `@hello-knip/lib-1/*` file imports in whether `@hello-knip/lib-1` is a used dependency.

Seems to stem from typescript not resolving the import as an `isExternalLibraryImport` module

(Is faulted by side-effect-only imports or imports not matching a file in the library)